### PR TITLE
Update cloudbuild.yaml to reference new secret configuration

### DIFF
--- a/backend/cloudbuild.yaml
+++ b/backend/cloudbuild.yaml
@@ -32,17 +32,9 @@ options:
   logging: 'CLOUD_LOGGING_ONLY'
 availableSecrets:
   secretManager:
-#    - versionName: projects/632351198383/secrets/DATABASE_URL/versions/latest
-#      env: 'DATABASE_URL'
-#    - versionName: projects/632351198383/secrets/GCP_SERVICE_ACCOUNT/versions/latest
-#      env: 'GCP_SERVICE_ACCOUNT'
-#    - versionName: projects/632351198383/secrets/FIRE_SERVICE_ACCOUNT/versions/latest
-#      env: 'FIRE_SERVICE_ACCOUNT'
-#    - versionName: projects/632351198383/secrets/GOOGLE_MAPS_API_KEY/versions/latest
-#      env: 'GOOGLE_MAPS_API_KEY'
-#    - versionName: projects/632351198383/secrets/STRIPE_API_KEY/versions/latest
-#      env: 'STRIPE_API_KEY'
-#    - versionName: projects/632351198383/secrets/STRIPE_WEBHOOK_SECRET/versions/latest
-#      env: 'STRIPE_WEBHOOK_SECRET'
-#    - versionName: projects/632351198383/secrets/EKISPERT_API_KEY/versions/latest
-#      env: 'EKISPERT_API_KEY'
+    - versionName: projects/223226992422/secrets/FIRE_SA/versions/latest
+      env: 'FIRE_SA'
+    - versionName: projects/223226992422/secrets/GEMINI_API_KEY/versions/latest
+      env: 'GEMINI_API_KEY'
+    - versionName: projects/223226992422/secrets/GOOGLE_MAPS_API_KEY/versions/latest
+      env: 'GOOGLE_MAPS_API_KEY'


### PR DESCRIPTION
Replaced commented-out old secret references with active secrets for FIRE_SA, GEMINI_API_KEY, and GOOGLE_MAPS_API_KEY. This ensures the build process now uses the updated secret manager configurations.

## 関連するIssue
- #issue番号

## 変更内容
- 

## なぜこの変更が必要か
## 変更の検証方法
1. 

## スクリーンショット/デモ
## チェックリスト
- [ ] 関連するIssueへのリンクが記述されているか
- [ ] コードがプロジェクトのコーディング規約に従っているか
- [ ] 新しいテストが追加されたか、または既存のテストがパスしているか
- [ ] ドキュメントが更新されたか (必要な場合)
- [ ] セルフレビューを行ったか

## レビュアーへの特記事項


Close #ISSUE_NUMBER
