### PR TITLE
Add intent queries for URL handling on Android API 30+

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,25 @@
     <!-- 広告ID -->
     <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
 
+    <!-- Required to use url_launcher -->
+    <!-- Provide required visibility configuration for API level 30 and above -->
+    <queries>
+        <!-- If your app checks for SMS support -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="sms" />
+        </intent>
+        <!-- If your app checks for call support -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="tel" />
+        </intent>
+        <!-- If your application checks for inAppBrowserView launch mode support -->
+        <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+    </queries>
+
     <application
         android:label="Diarlies"
         android:name="${applicationName}"

--- a/mobile/lib/pages/home/settings/action.dart
+++ b/mobile/lib/pages/home/settings/action.dart
@@ -106,7 +106,7 @@ class HomeSettingsAction extends FluxAction {
   Future<void> openPrivacyPolicyPage() async {
     final url = Uri.parse(Urls.privacyPolicy);
     if (await canLaunchUrl(url)) {
-      await launchUrl(url, mode: LaunchMode.inAppWebView);
+      await launchUrl(url);
     } else {
       throw Exception('Could not launch $url');
     }


### PR DESCRIPTION
Updated AndroidManifest.xml to include intent queries required for URL handling with url_launcher and API level 30+. This ensures proper functionality for SMS, call, and in-app browser intents. These changes address visibility configuration requirements introduced in newer Android versions.

## 関連するIssue
- #issue番号

## 変更内容
- 

## なぜこの変更が必要か
## 変更の検証方法
1. 

## スクリーンショット/デモ
## チェックリスト
- [ ] 関連するIssueへのリンクが記述されているか
- [ ] コードがプロジェクトのコーディング規約に従っているか
- [ ] 新しいテストが追加されたか、または既存のテストがパスしているか
- [ ] ドキュメントが更新されたか (必要な場合)
- [ ] セルフレビューを行ったか

## レビュアーへの特記事項


Close #ISSUE_NUMBER
